### PR TITLE
Allows Remapping L1 on the Shelly

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,13 @@ Within the project there is a file `/data/dbus-shelly-3em-smartmeter/config.ini`
 | ONPREMISE  | Host | IP or hostname of on-premise Shelly 3EM web-interface |
 | ONPREMISE  | Username | Username for htaccess login - leave blank if no username/password required |
 | ONPREMISE  | Password | Password for htaccess login - leave blank if no username/password required |
+| ONPREMISE  | L1Position | Which input on the Shelly in 3-phase grid is supplying a single Multi |
 
 
+### Remapping L1
+In a 3-phase grid with a single Multi, Venus OS expects L1 to be supplying the only Multi. This is not always the case. If for example your Multi is supplied by L3 (Input `C` on the Shelly) your GX device will show AC Loads as consuming from both L1 and L3. Setting `L1Position` to the appropriate Shelly input allows for remapping the phases and showing correct data on the GX device.
+
+If your single Multi is connected to the Input `A` on the Shelly you don't need to change this setting. Setting `L1Position` to `2` would swap the `B` CT & Voltage sensors data on the Shelly with the `A` CT & Voltage sensors data on the Shelly. Respectively, setting `L1Position` to `3` would swap `A` and `C` inputs.
 
 ## Used documentation
 - https://github.com/victronenergy/venus/wiki/dbus#grid   DBus paths for Victron namespace GRID

--- a/config.ini
+++ b/config.ini
@@ -14,3 +14,5 @@ LogLevel=ERROR
 Host=192.168.2.13
 Username=
 Password=
+# Allows to specify which input on the Shelly should correspond to L1 on the Venus/GX device
+L1Position = 1

--- a/dbus-shelly-3em-smartmeter.py
+++ b/dbus-shelly-3em-smartmeter.py
@@ -146,8 +146,19 @@ class DbusShelly3emService:
  
   def _update(self):   
     try:
-       #get data from Shelly 3em
-       meter_data = self._getShellyData()
+      #get data from Shelly 3em
+      meter_data = self._getShellyData()
+      config = self._getConfig()
+
+      try:
+        remapL1 = int(config['ONPREMISE']['L1Position'])
+      except KeyError:
+        remapL1 = 1
+
+      if remapL1 > 1:
+        old_l1 = meter_data['emeters'][0]
+        meter_data['emeters'][0] = meter_data['emeters'][remapL1-1]
+        meter_data['emeters'][remapL1-1] = old_l1
        
        #send data to DBus
        self._dbusservice['/Ac/Power'] = meter_data['total_power']


### PR DESCRIPTION
This PR addresses the issue [discussed here](https://community.victronenergy.com/questions/125793/shelly-3em-smartmeter-with-venusos-cerbo-gx.html?childToView=131391#comment-131391)

When there's 3 phase grid, but only 1 multi, and that multi is not supplied with the input A, measured by the Shelly, the Venus/GX device would wrongly show its own powered AC Loads on L1, but also show the incoming power on one of the other phases, although that's the input itself.

What this PR does is to effectively swap the measurements retrieved from the Shelly to properly map the Multi's supplying phase to L1, whenever it is different.